### PR TITLE
Update to 1.3.1

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = python-liquidctl
 	pkgdesc = Cross-platform tool and drivers for liquid coolers and other devices
-	pkgver = 1.3.0
+	pkgver = 1.3.1
 	pkgrel = 1
 	url = https://github.com/jonasmalacofilho/liquidctl
 	arch = any
@@ -10,8 +10,8 @@ pkgbase = python-liquidctl
 	depends = python-pyusb
 	depends = python-hidapi
 	depends = python-docopt
-	source = https://files.pythonhosted.org/packages/source/l/liquidctl/liquidctl-1.3.0.tar.gz
-	sha256sums = ce0483b0a7f9cf2618cb30bdf3ff4195e20d9df6c615f69afe127f54956e42ce
+	source = https://files.pythonhosted.org/packages/source/l/liquidctl/liquidctl-1.3.1.tar.gz
+	sha256sums = 6092a6fae477908c80adc825b290e39f0b26e604593884da23d40e892e553309
 
 pkgname = python-liquidctl
 	depends = python

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname=('python-liquidctl')
 _module='liquidctl'
-pkgver='1.3.0'
+pkgver='1.3.1'
 pkgrel=1
 pkgdesc="Cross-platform tool and drivers for liquid coolers and other devices"
 url="https://github.com/jonasmalacofilho/liquidctl"
@@ -9,7 +9,7 @@ makedepends=()
 license=('GPL3')
 arch=('any')
 source=("https://files.pythonhosted.org/packages/source/l/liquidctl/liquidctl-${pkgver}.tar.gz")
-sha256sums=('ce0483b0a7f9cf2618cb30bdf3ff4195e20d9df6c615f69afe127f54956e42ce')
+sha256sums=('6092a6fae477908c80adc825b290e39f0b26e604593884da23d40e892e553309')
 
 build() {
     cd "${srcdir}/${_module}-${pkgver}"


### PR DESCRIPTION
Released 23 November 2019.

 * Fix parsing of `--verbose` in commands other than `list`

Check the complete [CHANGELOG.md](https://github.com/jonasmalacofilho/liquidctl/blob/master/CHANGELOG.md).